### PR TITLE
Update ReadME with common template format

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ junos
 
 We welcome community contributions to this collection. If you find problems, please open an issue or create a PR against this repository.
 
+Don't know how to start? Refer to the [Ansible community guide](https://docs.ansible.com/ansible/devel/community/index.html)!
+
+Want to submit code changes? Take a look at the [Quick-start development guide](https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html).
+
+We also use the following guidelines:
+
+* [Collection review checklist](https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_reviewing.html)
+* [Ansible development guide](https://docs.ansible.com/ansible/devel/dev_guide/index.html)
+* [Ansible collection development guide](https://docs.ansible.com/ansible/devel/dev_guide/developing_collections.html#contributing-to-collections)
+
 ### Code of Conduct
 This collection follows the Ansible project's
 [Code of Conduct](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 - Network Backup collection can be used by anyone who are looking to manage and maintain network infrastructure, automate the backup process, and ensure data is regularly and securely backed up. This includes system administrators and IT professionals.
 
 ## Requirements
-- Requires `ansible >= 2.14.0`
+- [Requires Ansible](https://github.com/redhat-cop/network.backup/blob/main/meta/runtime.yml)
+- [Requires Content Collections](https://github.com/redhat-cop/network.backup/blob/main/galaxy.yml#L5https://forum.ansible.com/c/news/5/none)
+- [Testing Requirements](https://github.com/redhat-cop/network.backup/blob/main/test-requirements.txt)
 
 ## Installation
 To consume this Validated Content from Automation Hub, the following needs to be added to ansible.cfg:

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7404/badge)](https://bestpractices.coreinfrastructure.org/projects/7404)
 
 
-# About 
+## About
 - Ansible Network Backup Collection contains the role which provides a platform-agnostic way of managing network backup on supported network platforms. This collection provides the user the capabilities to create, compare and tag backups supporting local and remote data stores.
 
 - Network Backup collection can be used by anyone who are looking to manage and maintain network infrastructure, automate the backup process, and ensure data is regularly and securely backed up. This includes system administrators and IT professionals.
 
-# Requirements
+## Requirements
 - Requires `ansible >= 2.14.0`
 
-# Installation
+## Installation
 To consume this Validated Content from Automation Hub, the following needs to be added to ansible.cfg:
 ```
 [galaxy]
@@ -33,7 +33,7 @@ ansible-galaxy collection install network.base
 ansible-galaxy collection install network.backup
 ```
 
-# Use Cases
+## Use Cases
 
 `Full Backup`:
 - This enables the user to fetch running network configuration from the device and save the backup to a local or remote data store
@@ -130,7 +130,7 @@ run.yml
                 email: "{{ email }}"
 ```
 
-# Testing
+## Testing
 
 The project uses tox to run `ansible-lint` and `ansible-test sanity`.
 Assuming this repository is checked out in the proper structure,
@@ -160,20 +160,20 @@ junos
   ansible-test network-integration -i /path/to/inventory --python 3.9 [target]
 ```
 
-# Contributing
+## Contributing
 
 We welcome community contributions to this collection. If you find problems, please open an issue or create a PR against this repository.
 
-## Code of Conduct
+### Code of Conduct
 This collection follows the Ansible project's
 [Code of Conduct](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html).
 Please read and familiarize yourself with this document.
 
-# Release notes
+## Release notes
 
 Release notes are available [here](https://github.com/redhat-cop/network.backup/blob/main/CHANGELOG.rst).
 
-# Related information
+## Related information
 
 - [Developing network resource modules](https://docs.ansible.com/ansible/latest/network/dev_guide/developing_resource_modules_network.html#developing-resource-modules)
 - [Ansible network resources](https://docs.ansible.com/ansible/latest/network/getting_started/network_resources.html)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
 - [Requires Ansible](https://github.com/redhat-cop/network.backup/blob/main/meta/runtime.yml)
 - [Requires Content Collections](https://github.com/redhat-cop/network.backup/blob/main/galaxy.yml#L5https://forum.ansible.com/c/news/5/none)
 - [Testing Requirements](https://github.com/redhat-cop/network.backup/blob/main/test-requirements.txt)
+- Users also need to include platform collections as per their requirements. The supported platform collections are:
+  - [arista.eos](https://github.com/ansible-collections/arista.eos)
+  - [cisco.ios](https://github.com/ansible-collections/cisco.ios)
+  - [cisco.iosxr](https://github.com/ansible-collections/cisco.iosxr)
+  - [cisco.nxos](https://github.com/ansible-collections/cisco.nxos)
+  - [junipernetworks.junos](https://github.com/ansible-collections/junipernetworks.junos)
 
 ## Installation
 To consume this Validated Content from Automation Hub, the following needs to be added to ansible.cfg:
@@ -187,8 +193,8 @@ Release notes are available [here](https://github.com/redhat-cop/network.backup/
 
 ## Related information
 
-- [Developing network resource modules](https://docs.ansible.com/ansible/latest/network/dev_guide/developing_resource_modules_network.html#developing-resource-modules)
-- [Ansible network resources](https://docs.ansible.com/ansible/latest/network/getting_started/network_resources.html)
+- [Developing network resource modules](https://github.com/ansible-network/networking-docs/blob/main/rm_dev_guide.md)
+- [Ansible Networking docs](https://github.com/ansible-network/networking-docs)
 - [Ansible Collection Overview](https://github.com/ansible-collections/overview)
 - [Ansible Roles overview](https://docs.ansible.com/ansible/2.9/user_guide/playbooks_reuse_roles.html)
 - [Ansible User guide](https://docs.ansible.com/ansible/latest/user_guide/index.html)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Ansible Network Backup
 [![CI](https://github.com/ansible-network/network.backup/actions/workflows/tests.yml/badge.svg?event=schedule)](https://github.com/ansible-network/network.backup/actions/workflows/tests.yml)
-[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7404/badge)](https://bestpractices.coreinfrastructure.org/projects/8253)
+[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7404/badge)](https://bestpractices.coreinfrastructure.org/projects/7404)
 
 
 # About 
@@ -19,7 +19,7 @@ To consume this Validated Content from Automation Hub, the following needs to be
 server_list = automation_hub
 
 [galaxy_server.automation_hub]
-url=https://cloud.redhat.com/api/automation-hub/
+url=https://console.redhat.com/api/automation-hub/content/published/
 auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
 token=<SuperSecretToken>
 ```
@@ -36,11 +36,11 @@ ansible-galaxy collection install network.backup
 # Use Cases
 
 `Full Backup`:
-- This enables the user to fetch running configuration from the device and save the backup to a local or remote data store
+- This enables the user to fetch running network configuration from the device and save the backup to a local or remote data store
 - Users can also push backup files onto GitHub with tags.
  
 `Differential backup`:
-- This enables users to backup configuration only when there has been some change since the last time we did a backup.
+- This enables users to backup network configuration only when there has been some change since the last time we did a backup.
 - Users can use this operation to get differential backup and save the backed-up files to either the local data store or to the GitHub repository
 - Users can also push backup files onto GitHub with tags.
 
@@ -132,8 +132,6 @@ run.yml
 
 # Testing
 
-### ansible-core
-
 The project uses tox to run `ansible-lint` and `ansible-test sanity`.
 Assuming this repository is checked out in the proper structure,
 e.g. `collections_root/ansible_collections/network/backup`, run:
@@ -162,22 +160,18 @@ junos
   ansible-test network-integration -i /path/to/inventory --python 3.9 [target]
 ```
 
-# Release notes
+# Contributing
 
-Release notes are available [here](https://github.com/redhat-cop/network.backup/blob/main/CHANGELOG.rst).
+We welcome community contributions to this collection. If you find problems, please open an issue or create a PR against this repository.
 
-### See Also:
-
-* [Ansible Using roles](https://docs.ansible.com/ansible/2.9/user_guide/playbooks_reuse_roles.html) for more details.
-
-## Advantages of Using this Role
-Provide a single platform agnostics entry point to manage network backup and restore use cases.
-
-### Code of Conduct
+## Code of Conduct
 This collection follows the Ansible project's
 [Code of Conduct](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html).
 Please read and familiarize yourself with this document.
 
+# Release notes
+
+Release notes are available [here](https://github.com/redhat-cop/network.backup/blob/main/CHANGELOG.rst).
 
 # Related information
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,38 @@
 [![CI](https://github.com/ansible-network/network.backup/actions/workflows/tests.yml/badge.svg?event=schedule)](https://github.com/ansible-network/network.backup/actions/workflows/tests.yml)
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7404/badge)](https://bestpractices.coreinfrastructure.org/projects/7404)
 
-Ansible Network Backup Collection provides a platform-agnostic way of managing network backup on supported network devices.
 
+# About 
+- Ansible Network Backup Collection contains the  the role which provides a platform-agnostic way of managing network backup on supported network platforms.This collection provides the user the capabilities to create, compare and tag backups supporting local and  remote data stores.
 
-## Using the platform-agnostic role network.backup.run as part of a network.backup collection.
+- Network Backup collection  can be used by anyone who are looking for managing and maintaining network infrastructure, automate the backup process, ensuring data is regularly and securely backed up. This includes system administrators and IT professionals.
 
-## Capabilities
+# Requirements
+- Requires `ansible >= 2.14.0`
+
+# Installation
+To consume this Validated Content from Automation Hub, the following needs to be added to ansible.cfg:
+```
+[galaxy]
+server_list = automation_hub
+
+[galaxy_server.automation_hub]
+url=https://cloud.redhat.com/api/automation-hub/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+token=<SuperSecretToken>
+```
+
+Get the required token from the [Automation Hub Web UI](https://console.redhat.com/ansible/automation-hub/token).
+
+With this configured, simply run the following commands:
+
+```
+ansible-galaxy collection install network.base
+ansible-galaxy collection install network.backup
+```
+
+# Use Cases
+
 `Full Backup`:
 - This enables the user to fetch running configuration from the device and save the backup to local or remote data-store
 - Users can also push backup files onto GitHub with tags.
@@ -18,7 +44,6 @@ Ansible Network Backup Collection provides a platform-agnostic way of managing n
 - Users can use this operation to get differential backup and save the backed-up files to either the local data store or to the GitHub repository
 - Users can also push backup files onto GitHub with tags.
 
-## Examples
 
 ### Full Network Backup
 
@@ -105,6 +130,42 @@ run.yml
                 email: "{{ email }}"
 ```
 
+# Testing
+
+### ansible-core
+
+The project uses tox to run `ansible-lint` and `ansible-test sanity`.
+Assuming this repository is checked out in the proper structure,
+e.g. `collections_root/ansible_collections/network/backup`, run:
+
+```shell
+  tox -e ansible-lint
+  tox -e py39-sanity
+```
+
+To run integration tests, ensure that your inventory has a `network_base` group.
+Depending on what test target you are running, comment out the host(s).
+
+```shell
+[network_hosts]
+ios
+junos
+
+[ios:vars]
+< enter inventory details for this group >
+
+[junos:vars]
+< enter inventory details for this group >
+```
+
+```shell
+  ansible-test network-integration -i /path/to/inventory --python 3.9 [target]
+```
+
+# Release notes
+
+Release notes are available [here](https://github.com/redhat-cop/network.backup/blob/main/CHANGELOG.rst).
+
 ### See Also:
 
 * [Ansible Using roles](https://docs.ansible.com/ansible/2.9/user_guide/playbooks_reuse_roles.html) for more details.
@@ -118,7 +179,7 @@ This collection follows the Ansible project's
 Please read and familiarize yourself with this document.
 
 
-## More information
+# Related information
 
 - [Developing network resource modules](https://docs.ansible.com/ansible/latest/network/dev_guide/developing_resource_modules_network.html#developing-resource-modules)
 - [Ansible network resources](https://docs.ansible.com/ansible/latest/network/getting_started/network_resources.html)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 
 # Ansible Network Backup
 [![CI](https://github.com/ansible-network/network.backup/actions/workflows/tests.yml/badge.svg?event=schedule)](https://github.com/ansible-network/network.backup/actions/workflows/tests.yml)
-[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7404/badge)](https://bestpractices.coreinfrastructure.org/projects/7404)
+[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7404/badge)](https://bestpractices.coreinfrastructure.org/projects/8253)
 
 
 # About 
-- Ansible Network Backup Collection contains the  the role which provides a platform-agnostic way of managing network backup on supported network platforms.This collection provides the user the capabilities to create, compare and tag backups supporting local and  remote data stores.
+- Ansible Network Backup Collection contains the role which provides a platform-agnostic way of managing network backup on supported network platforms. This collection provides the user the capabilities to create, compare and tag backups supporting local and remote data stores.
 
-- Network Backup collection  can be used by anyone who are looking for managing and maintaining network infrastructure, automate the backup process, ensuring data is regularly and securely backed up. This includes system administrators and IT professionals.
+- Network Backup collection can be used by anyone who are looking to manage and maintain network infrastructure, automate the backup process, and ensure data is regularly and securely backed up. This includes system administrators and IT professionals.
 
 # Requirements
 - Requires `ansible >= 2.14.0`
@@ -36,7 +36,7 @@ ansible-galaxy collection install network.backup
 # Use Cases
 
 `Full Backup`:
-- This enables the user to fetch running configuration from the device and save the backup to local or remote data-store
+- This enables the user to fetch running configuration from the device and save the backup to a local or remote data store
 - Users can also push backup files onto GitHub with tags.
  
 `Differential backup`:

--- a/changelogs/fragments/readme_changes.yaml
+++ b/changelogs/fragments/readme_changes.yaml
@@ -1,0 +1,3 @@
+---
+doc_changes:
+  - Update README


### PR DESCRIPTION
These changes are the outcome of the README template which was developed by the Docs Team to give us a more robust README outline for internal and partner collections. 


![Screenshot from 2024-01-17 11-23-40](https://github.com/redhat-cop/network.backup/assets/30184562/3e3e3c40-ca84-4f6c-8ea9-c4002d1c6905)
