### PR TITLE
Fix the network OS validation task to allow OS without FQCN.

### DIFF
--- a/changelogs/fragments/without_fqcn_os_fix.yaml
+++ b/changelogs/fragments/without_fqcn_os_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix the task to allow supported os name without fqcn.

--- a/roles/run/includes/validation.yaml
+++ b/roles/run/includes/validation.yaml
@@ -1,5 +1,4 @@
 ---
-
 - name: Set supported platform list
   ansible.builtin.set_fact:
     supported_platforms:
@@ -12,4 +11,4 @@
 
 - name: Conditional test
   ansible.builtin.include_tasks: "includes/unsupported_platform.yaml"
-  when: 'ansible_network_os in supported_platforms'
+  when: ansible_network_os.split('.')[-1] not in supported_platforms


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Fix the ansible_network_os validation task to allow
ansible_network_os without fqcn.
- resolves:  https://github.com/redhat-cop/network.backup/issues/15
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 



##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
