### PR TITLE
Update documentation to define installation instructions and bump to ansible 2.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ To consume this Validated Content from Automation Hub, the following needs to be
 server_list = automation_hub
 
 [galaxy_server.automation_hub]
-url=https://console.redhat.com/api/automation-hub/content/published/
+url=https://console.redhat.com/api/automation-hub/content/validated/
 auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
 token=<SuperSecretToken>
 ```
 
-Get the required token from the [Automation Hub Web UI](https://console.redhat.com/ansible/automation-hub/token).
+Utilize the current Token, and if the token has expired, obtain the necessary
+token from the [Automation Hub Web UI](https://console.redhat.com/ansible/automation-hub/token).
 
 With this configured, simply run the following commands:
 

--- a/changelogs/fragments/bump_to_215.yaml
+++ b/changelogs/fragments/bump_to_215.yaml
@@ -1,7 +1,7 @@
 ---
 doc_changes:
   - Updated the URL to point to validated content instead of certified content.
-  - Revised the instructions on when to utilize the token.n.
+  - Revised the instructions on when to utilize the token.
 release_summary: >
   With this release, the minimum required version of `ansible-core` for this collection is `2.15.0`.
   The last version known to be compatible with `ansible-core` versions below `2.15` is v2.0.0.

--- a/changelogs/fragments/bump_to_215.yaml
+++ b/changelogs/fragments/bump_to_215.yaml
@@ -1,0 +1,9 @@
+---
+doc_changes:
+  - Updated the URL to point to validated content instead of certified content.
+  - Revised the instructions on when to utilize the token.n.
+release_summary: >
+  With this release, the minimum required version of `ansible-core` for this collection is `2.15.0`.
+  The last version known to be compatible with `ansible-core` versions below `2.15` is v2.0.0.
+major_changes:
+  - Bumping `requires_ansible` to `>=2.15.0`, since previous ansible-core versions are EoL now.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"


### PR DESCRIPTION
doc_changes:
  - Updated the URL to point to validated content instead of certified content.
  - Revised the instructions on when to utilize the token.n.
release_summary: >
  With this release, the minimum required version of `ansible-core` for this collection is `2.15.0`.
  The last version known to be compatible with `ansible-core` versions below `2.15` is v2.0.0.
major_changes:
  - Bumping `requires_ansible` to `>=2.15.0`, since previous ansible-core versions are EoL now.